### PR TITLE
Adding updated features

### DIFF
--- a/src/MarkdownApi.Core/Builders/MarkdownBuilder.cs
+++ b/src/MarkdownApi.Core/Builders/MarkdownBuilder.cs
@@ -1,14 +1,14 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Text;
 
 namespace igloo15.MarkdownApi.Core.Builders
 {
-    /// <summary>
-    /// Builds Markdown strings
-    /// </summary>
-    public class MarkdownBuilder
+  /// <summary>
+  /// Builds Markdown strings
+  /// </summary>
+  public class MarkdownBuilder
     {
-        
+
         /// <summary>
         /// Places code in a markdown codeblock
         /// </summary>
@@ -18,7 +18,6 @@ namespace igloo15.MarkdownApi.Core.Builders
         {
             return "`" + code + "`";
         }
-
 
         StringBuilder sb = new StringBuilder();
 
@@ -44,7 +43,7 @@ namespace igloo15.MarkdownApi.Core.Builders
 
             return this;
         }
-        
+
         /// <summary>
         /// Appends a new line to the internal string builder
         /// </summary>
@@ -94,8 +93,6 @@ namespace igloo15.MarkdownApi.Core.Builders
         /// <returns>The MarkdownBuilder</returns>
         public MarkdownBuilder HeaderWithCode(int level, string code)
         {
-            
-
             for (int i = 0; i < level; i++)
             {
                 sb.Append("#");
@@ -190,18 +187,40 @@ namespace igloo15.MarkdownApi.Core.Builders
         }
 
         /// <summary>
-        /// Create a table with the header and given items
+        /// Create a table with the header and the given items and size
         /// </summary>
         /// <param name="headers">The header of table</param>
         /// <param name="items">The items on each row</param>
+        /// <param name="diffSizeCells">True, if cells next to each other have different width.</param>
         /// <returns>The MarkdownBuilder</returns>
-        public MarkdownBuilder Table(string[] headers, IEnumerable<string[]> items)
+        public MarkdownBuilder Table(string[] headers, IEnumerable<string[]> items, bool diffSizeCells)
         {
+            bool flag = false;
             sb.Append("| ");
             foreach (var item in headers)
             {
-                sb.Append(item);
-                sb.Append(" | ");
+                if (diffSizeCells)
+                {
+                    if (!flag)
+                    {
+                        sb.Append(item + "<div><a href=\"#\"><img width=225></a></div>");
+                        sb.Append(" | ");
+                        flag = true;
+                    }
+
+                    else
+                    {
+                        sb.Append(item + "<div><a href=\"#\"><img width=525></a></div>");
+                        sb.Append(" | ");
+                        flag = false;
+                    }
+                }
+
+                else
+                {
+                    sb.Append(item);
+                    sb.Append(" | ");
+                }
             }
             sb.AppendLine();
 
@@ -222,6 +241,7 @@ namespace igloo15.MarkdownApi.Core.Builders
                     sb.Append(item2);
                     sb.Append(" | ");
                 }
+
                 sb.AppendLine();
             }
             sb.AppendLine();

--- a/src/MarkdownApi.Core/Builders/MarkdownItemBuilder.cs
+++ b/src/MarkdownApi.Core/Builders/MarkdownItemBuilder.cs
@@ -1,6 +1,4 @@
-﻿
-using igloo15.MarkdownApi.Core;
-using igloo15.MarkdownApi.Core.MarkdownItems;
+﻿using igloo15.MarkdownApi.Core.MarkdownItems;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
 using System;
@@ -8,16 +6,15 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using System.Xml.Linq;
 
 namespace igloo15.MarkdownApi.Core.Builders
 {
-    
+
     internal static class MarkdownItemBuilder
     {
+        public static string xmlPath;
         public static MarkdownProject Load(string searchArea, string namespaceMatch)
         {
             List<MarkdownType> types = new List<MarkdownType>();
@@ -27,7 +24,7 @@ namespace igloo15.MarkdownApi.Core.Builders
             AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
 
             var matcher = new Matcher();
-            foreach(var searchPath in searchArea.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+            foreach (var searchPath in searchArea.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
             {
                 matcher.AddInclude(searchPath);
             }
@@ -40,7 +37,7 @@ namespace igloo15.MarkdownApi.Core.Builders
                 var dllName = Path.GetFileName(dllPath);
                 Constants.Logger?.LogInformation("Loading Dll: {dllName}", dllPath);
 
-                if(processedDlls.Contains(dllName))
+                if (processedDlls.Contains(dllName))
                 {
                     Constants.Logger?.LogWarning("Duplicate Dll: {dllName}", dllName);
                     continue;
@@ -48,7 +45,7 @@ namespace igloo15.MarkdownApi.Core.Builders
 
                 try
                 {
-                    if(File.Exists(dllPath) && Path.GetExtension(dllPath) == ".dll")
+                    if (File.Exists(dllPath) && Path.GetExtension(dllPath) == ".dll")
                     {
                         LoadDll(dllPath, namespaceMatch);
                         processedDlls.Add(dllName);
@@ -73,10 +70,11 @@ namespace igloo15.MarkdownApi.Core.Builders
             var dllName = Path.GetFileNameWithoutExtension(dllPath);
             var commentsLookup = GetComments(dllPath, namespaceMatch);
 
-            var namespaceRegex = 
+            var namespaceRegex =
                 !string.IsNullOrEmpty(namespaceMatch) ? new Regex(namespaceMatch) : null;
 
-            IEnumerable<Type> AssemblyTypesSelector(Assembly x) {
+            IEnumerable<Type> AssemblyTypesSelector(Assembly x)
+            {
 
                 try
                 {
@@ -96,7 +94,7 @@ namespace igloo15.MarkdownApi.Core.Builders
                 }
             }
 
-            bool NotNullPredicate(Type x )
+            bool NotNullPredicate(Type x)
             {
                 return x != null;
             }
@@ -121,7 +119,7 @@ namespace igloo15.MarkdownApi.Core.Builders
                 return IsPublic && !IsAssignableFromDelegate && !HaveObsoleteAttribute;
             }
 
-            
+
 
             var dllAssemblys = new[] { Assembly.LoadFile(dllPath) };
 
@@ -169,19 +167,22 @@ namespace igloo15.MarkdownApi.Core.Builders
             }
         }
 
-        static bool IsRequiredNamespace(Type type, Regex regex) {
-            if ( regex == null ) {
+        static bool IsRequiredNamespace(Type type, Regex regex)
+        {
+            if (regex == null)
+            {
                 return true;
             }
             return regex.IsMatch(type.Namespace != null ? type.Namespace : string.Empty);
         }
 
-        static ILookup<string, XmlDocumentComment> GetComments(string dllPath, string namespaceMatch)
+       static ILookup<string, XmlDocumentComment> GetComments(string dllPath, string namespaceMatch)
         {
             var dllName = Path.GetFileNameWithoutExtension(dllPath);
-            var xmlPath = Path.Combine(Directory.GetParent(dllPath).FullName, dllName + ".xml");
+            xmlPath = Path.Combine(Directory.GetParent(dllPath).FullName, dllName + ".xml");
 
             XmlDocumentComment[] comments = new XmlDocumentComment[0];
+
             if (File.Exists(xmlPath))
             {
                 comments = VSDocParser.ParseXmlComment(XDocument.Parse(File.ReadAllText(xmlPath)), namespaceMatch);

--- a/src/MarkdownApi.Core/Builders/MarkdownTypeBuilder.cs
+++ b/src/MarkdownApi.Core/Builders/MarkdownTypeBuilder.cs
@@ -1,13 +1,12 @@
 ﻿using igloo15.MarkdownApi.Core.MarkdownItems;
 using igloo15.MarkdownApi.Core.MarkdownItems.TypeParts;
-using igloo15.MarkdownApi.Core.Themes.Default;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace igloo15.MarkdownApi.Core.Builders
 {
-    internal class MarkdownTypeBuilder
+  internal class MarkdownTypeBuilder
     {
         public List<MarkdownNamespace> BuildTypes(MarkdownType[] types, ILookup<string, XmlDocumentComment> comments)
         {
@@ -20,6 +19,7 @@ namespace igloo15.MarkdownApi.Core.Builders
                 var myNamespace = MarkdownRepo.TryGetOrAdd(type.InternalType.Namespace, tempNamespace);
 
                 var typeComments = comments[type.FullName];
+
 
                 if (!type.InternalType.IsEnum)
                 {
@@ -48,7 +48,7 @@ namespace igloo15.MarkdownApi.Core.Builders
             type.NamespaceItem = namespaceItem;
 
             type.Summary = comments.FirstOrDefault(x => x.MemberName == type.Name
-                    || x.MemberName.StartsWith(type.Name + "`"))?.Summary ?? "";
+                    || x.MemberName.StartsWith(type.Name))?.Summary ?? "";
 
             Constants.Logger?.LogTrace("Getting Markdown Fields for Type {typeName}", type.Name);
             BuildFields(type, comments, type.GetFields().Together(type.GetStaticFields()).ToArray());
@@ -105,7 +105,7 @@ namespace igloo15.MarkdownApi.Core.Builders
                 type.Methods.Add(item);
                 MarkdownRepo.TryAdd(item);
 
-                item.Summary = memberComments.Where(mc => mc.MemberName == item.InternalItem.GetCommentName()).FirstOrDefault(a => MethodCommentFilter(a, item))?.Summary ?? "";
+               item.Summary = memberComments.Where(mc => mc.MemberName == item.InternalItem.GetCommentName()).FirstOrDefault(a => MethodCommentFilter(a, item))?.Summary ?? "";
             }
         }
 

--- a/src/MarkdownApi.Core/Builders/VSDocParser.cs
+++ b/src/MarkdownApi.Core/Builders/VSDocParser.cs
@@ -1,278 +1,342 @@
-﻿using System;
+using igloo15.MarkdownApi.Core.Themes.Default;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using System.Xml.Linq;
 
 namespace igloo15.MarkdownApi.Core.Builders
 {
+  /// <summary>
+  /// Type of Xml Comment
+  /// </summary>
+  public enum MemberType
+  {
     /// <summary>
-    /// Type of Xml Comment
+    /// Xml comment for field
     /// </summary>
-    public enum MemberType
-    {
-        /// <summary>
-        /// Xml comment for field
-        /// </summary>
-        Field = 'F',
-
-        /// <summary>
-        /// Xml Comment for Property
-        /// </summary>
-        Property = 'P',
-
-        /// <summary>
-        /// Xml Comment for Type
-        /// </summary>
-        Type = 'T',
-
-        /// <summary>
-        /// Xml comment for Event
-        /// </summary>
-        Event = 'E',
-
-        /// <summary>
-        /// Xml comment for Method
-        /// </summary>
-        Method = 'M',
-
-        /// <summary>
-        /// Xml comment for none
-        /// </summary>
-        None = 0
-    }
+    Field = 'F',
 
     /// <summary>
-    /// Xml Comment in Xml Document
+    /// Xml Comment for Property
     /// </summary>
-    public class XmlDocumentComment
+    Property = 'P',
+
+    /// <summary>
+    /// Xml Comment for Type
+    /// </summary>
+    Type = 'T',
+
+    /// <summary>
+    /// Xml comment for Event
+    /// </summary>
+    Event = 'E',
+
+    /// <summary>
+    /// Xml comment for Method
+    /// </summary>
+    Method = 'M',
+
+    /// <summary>
+    /// Xml comment for none
+    /// </summary>
+    None = 0
+  }
+
+  /// <summary>
+  /// Xml Comment in Xml Document
+  /// </summary>
+  public class XmlDocumentComment
+  {
+    /// <summary>
+    /// The type of comment
+    /// </summary>
+    public MemberType MemberType { get; internal set; }
+
+    /// <summary>
+    /// The class name for the comment
+    /// </summary>
+    public string ClassName { get; internal set; }
+
+    /// <summary>
+    /// The Member Name for this comment
+    /// </summary>
+    public string MemberName { get; internal set; }
+
+    /// <summary>
+    /// The Summary comment
+    /// </summary>
+    public string Summary { get; internal set; }
+
+    /// <summary>
+    /// The Remarks of the comment
+    /// </summary>
+    public string Remarks { get; internal set; }
+
+    /// <summary>
+    /// Any parameter summaries of comment
+    /// </summary>
+    public Dictionary<string, string> Parameters { get; internal set; }
+
+    /// <summary>
+    /// The summary of the return
+    /// </summary>
+    public string Returns { get; internal set; }
+
+    /// <summary>
+    /// Converts comment to a single string summary
+    /// </summary>
+    /// <returns></returns>
+    public override string ToString()
     {
-        /// <summary>
-        /// The type of comment
-        /// </summary>
-        public MemberType MemberType { get; internal set; }
+      return MemberType + ":" + ClassName + "." + MemberName;
+    }
+  }
 
-        /// <summary>
-        /// The class name for the comment
-        /// </summary>
-        public string ClassName { get; internal set; }
-
-        /// <summary>
-        /// The Member Name for this comment
-        /// </summary>
-        public string MemberName { get; internal set; }
-
-        /// <summary>
-        /// The Summary comment
-        /// </summary>
-        public string Summary { get; internal set; }
-
-        /// <summary>
-        /// The Remarks of the comment
-        /// </summary>
-        public string Remarks { get; internal set; }
-
-        /// <summary>
-        /// Any parameter summaries of comment
-        /// </summary>
-        public Dictionary<string, string> Parameters { get; internal set; }
-
-        /// <summary>
-        /// The summary of the return
-        /// </summary>
-        public string Returns { get; internal set; }
-
-        /// <summary>
-        /// Converts comment to a single string summary
-        /// </summary>
-        /// <returns></returns>
-        public override string ToString()
-        {
-            return MemberType + ":" + ClassName + "." + MemberName;
-        }
+  internal static class VSDocParser
+  {
+    public static XmlDocumentComment[] ParseXmlComment(XDocument xDocument)
+    {
+      return ParseXmlComment(xDocument, null);
     }
 
-    internal static class VSDocParser
+    // cheap, quick hack parser:)
+    internal static XmlDocumentComment[] ParseXmlComment(XDocument xDocument, string namespaceMatch)
     {
-        public static XmlDocumentComment[] ParseXmlComment(XDocument xDocument)
-        {
-            return ParseXmlComment(xDocument, null);
-        }
+      return xDocument.Descendants("member")
+          .Select(x =>
+          {
+            var match = Regex.Match(x.Attribute("name").Value, @"(.):(.+)\.([^.()]+)?(\(.+\)|$)");
+            if (!match.Groups[1].Success) return null;
 
-        // cheap, quick hack parser:)
-        internal static XmlDocumentComment[] ParseXmlComment(XDocument xDocument, string namespaceMatch)
-        {
-            return xDocument.Descendants("member")
-                .Select(x =>
+            var memberType = (MemberType)match.Groups[1].Value[0];
+            if (memberType == MemberType.None) return null;
+
+            var summaryXml = x.Elements("summary").FirstOrDefault()?.ToString()
+                      ?? x.Element("summary")?.ToString()
+                      ?? "";
+
+            summaryXml = Regex.Replace(summaryXml, @"<\/?summary>", string.Empty);
+            summaryXml = Regex.Replace(summaryXml, "<para>", "<br>"); // replace para with a new line
+                  summaryXml = Regex.Replace(summaryXml, "</para>", string.Empty); // remove closing para tag
+
+                  summaryXml = Regex.Replace(summaryXml, @"<see cref=""\w:([^\""]*)""\s*\/>", m => ResolveSeeElement(m, namespaceMatch));
+
+            var parsed = Regex.Replace(summaryXml, @"<(type)*paramref name=""([^\""]*)""\s*\/>", e => $"`{e.Groups[2].Value}`");
+
+
+            var summary = parsed;
+
+            if (summary != "")
+            {
+              summary = string.Join("  ", summary.Split(new[] { "\r", "\n", "\t" }, StringSplitOptions.RemoveEmptyEntries).Select(y => y.Trim()));
+            }
+
+
+            var returns = x.Elements("returns").FirstOrDefault()?.ToString()
+                      ?? x.Element("returns")?.ToString()
+                      ?? "";
+
+            returns = Regex.Replace(returns, @"<\/?returns>", string.Empty);
+
+            returns = Regex.Replace(returns, "<para>", "<br>");
+            returns = Regex.Replace(returns, "</para>", string.Empty);
+
+            returns = Regex.Replace(returns, @"<see cref=""\w:([^\""]*)""\s*\/>", e => ResolveSeeElement(e, namespaceMatch));
+            returns = Regex.Replace(returns, @"<(type)*paramref name=""([^\""]*)""\s*\/>", e => $"`{e.Groups[2].Value}`");
+
+            var remarks = ((string)x.Element("remarks")) ?? "";
+
+            var parameters = x.Elements("param")
+                      .Select(e => Tuple.Create(e.Attribute("name").Value, e))
+                      .Distinct(new Item1EqualityCompaerer<string, XElement>())
+                      .ToDictionary(e => e.Item1, e => e.Item2.Value);
+
+            if (memberType == MemberType.Method && match.Groups.Count > 3 && !string.IsNullOrEmpty(match.Groups[4].Value))
+            {
+              int index = 0;
+              Dictionary<string, string> methodParams = new Dictionary<string, string>();
+              var paramTypes = ParseXmlParameters(match.Groups[4].Value.Replace("(", "").Replace(")", ""));
+
+              foreach (var paramElem in x.Elements("param"))
+              {
+                string newName = paramElem.Attribute("name").Value;
+
+                if (index < paramTypes.Length)
                 {
-                    var match = Regex.Match(x.Attribute("name").Value, @"(.):(.+)\.([^.()]+)?(\(.+\)|$)");
-                    if (!match.Groups[1].Success) return null;
+                  newName = newName + ":" + paramTypes[index].Replace("0:", "");
+                }
+                methodParams.Add(newName, paramElem.Value);
+                index++;
+              }
+              parameters = methodParams;
+            }
 
-                    var memberType = (MemberType)match.Groups[1].Value[0];
-                    if (memberType == MemberType.None) return null;
+            var className = (memberType == MemberType.Type)
+                      ? match.Groups[2].Value + "." + match.Groups[3].Value
+                      : match.Groups[2].Value;
 
-                    var summaryXml = x.Elements("summary").FirstOrDefault()?.ToString()
-                        ?? x.Element("summary")?.ToString()
-                        ?? "";
-                    summaryXml = Regex.Replace(summaryXml, @"<\/?summary>", string.Empty);
-                    summaryXml = Regex.Replace(summaryXml, @"<para\s*/>", Environment.NewLine);
-                    summaryXml = Regex.Replace(summaryXml, @"<see cref=""\w:([^\""]*)""\s*\/>", m => ResolveSeeElement(m, namespaceMatch));
+            return new XmlDocumentComment
+            {
+              MemberType = memberType,
+              ClassName = className,
+              MemberName = match.Groups[3].Value,
+              Summary = summary.Trim(),
+              Remarks = remarks.Trim(),
+              Parameters = parameters,
+              Returns = returns.Trim()
+            };
+          })
+          .Where(x => x != null)
+          .ToArray();
+    }
 
-                    var parsed = Regex.Replace(summaryXml, @"<(type)*paramref name=""([^\""]*)""\s*\/>", e => $"`{e.Groups[1].Value}`");
+    internal static XmlDocumentComment[] ParseXmlParameterComment(XDocument xDocument, string namespaceMatch)
+    {
+      return xDocument.Descendants("member")
+          .Select(x =>
+          {
+            var match = Regex.Match(x.Attribute("name").Value, @"(.):(.+)\.([^.()]+)?(\(.+\)|$)");
 
-                    var summary = parsed;
-
-                    if (summary != "")
-                    {
-                        summary = string.Join("  ", summary.Split(new[] { "\r", "\n", "\t" }, StringSplitOptions.RemoveEmptyEntries).Select(y => y.Trim()));
-                    }
-
-                    var returns = ((string)x.Element("returns")) ?? "";
-                    var remarks = ((string)x.Element("remarks")) ?? "";
-
-                    var parameters = x.Elements("param")
+            var parameters = x.Elements("param")
                         .Select(e => Tuple.Create(e.Attribute("name").Value, e))
                         .Distinct(new Item1EqualityCompaerer<string, XElement>())
-                        .ToDictionary(e => e.Item1, e => e.Item2.Value);
+                        .ToDictionary(e => e.Item1, e => e.Item2.ToString());
 
-                    if (memberType == MemberType.Method && match.Groups.Count > 3 && !string.IsNullOrEmpty(match.Groups[4].Value))
-                    {
-                        int index = 0;
-                        Dictionary<string, string> methodParams = new Dictionary<string, string>();
-                        var paramTypes = ParseXmlParameters(match.Groups[4].Value.Replace("(", "").Replace(")", ""));
-
-                        foreach (var paramElem in x.Elements("param"))
-                        {
-                            string newName = paramElem.Attribute("name").Value;
-
-                            if (index < paramTypes.Length)
-                            {
-                                newName = newName + ":" + paramTypes[index].Replace("0:", "");
-                            }
-                            methodParams.Add(newName, paramElem.Value);
-                            index++;
-                        }
-                        parameters = methodParams;
-                    }
-
-                    var className = (memberType == MemberType.Type)
-                        ? match.Groups[2].Value + "." + match.Groups[3].Value
-                        : match.Groups[2].Value;
-
-                    return new XmlDocumentComment
-                    {
-                        MemberType = memberType,
-                        ClassName = className,
-                        MemberName = match.Groups[3].Value,
-                        Summary = summary.Trim(),
-                        Remarks = remarks.Trim(),
-                        Parameters = parameters,
-                        Returns = returns.Trim()
-                    };
-                })
-                .Where(x => x != null)
-                .ToArray();
-        }
-
-        private static int ParseParamType(string value, string[] tokens, int currIndex, List<string> newTypes)
-        {
-            var paramType = value;
-            if (paramType.Contains("{"))
+            return new XmlDocumentComment
             {
-                var index = paramType.IndexOf("{");
-                var newType = paramType.Substring(0, index);
-                var nextType = paramType.Substring(index + 1, paramType.Length - index - 1);
-
-                List<string> innerTypes = new List<string>();
-                currIndex = ParseParamType(nextType, tokens, currIndex, innerTypes);
-                if (currIndex < tokens.Length && !nextType.Contains("}"))
-                {
-                    do
-                    {
-                        paramType = tokens[currIndex];
-                        currIndex = ParseParamType(paramType, tokens, currIndex, innerTypes);
-                    }
-                    while (!paramType.Contains("}") && currIndex < tokens.Length);
-                }
-
-                var innerTypeValue = string.Join(",", innerTypes);
-
-                newTypes.Add($"{newType}{{{innerTypeValue}}}");
-            }
-            else if (paramType.Contains("}"))
-            {
-                newTypes.Add(paramType.Replace("}", ""));
-                currIndex++;
-            }
-            else
-            {
-                newTypes.Add(paramType);
-                currIndex++;
-            }
-
-            return currIndex;
-        }
-
-        private static string ResolveSeeElement(Match m, string ns)
-        {
-            var typeName = m.Groups[1].Value;
-            if (!string.IsNullOrWhiteSpace(ns))
-            {
-                if (typeName.StartsWith(ns))
-                {
-                    return $"[{typeName}]({Regex.Replace(typeName, $"\\.(?:.(?!\\.))+$", me => me.Groups[0].Value.Replace(".", "#").ToLower())})";
-                }
-            }
-            return $"`{typeName}`";
-        }
-
-        private class Item1EqualityCompaerer<T1, T2> : EqualityComparer<Tuple<T1, T2>>
-        {
-            public override bool Equals(Tuple<T1, T2> x, Tuple<T1, T2> y)
-            {
-                return x.Item1.Equals(y.Item1);
-            }
-
-            public override int GetHashCode(Tuple<T1, T2> obj)
-            {
-                return obj.Item1.GetHashCode();
-            }
-        }
-
-        /// <summary>
-        /// Parse Xml Parameters with support from C# Discord and Nox#8248
-        /// </summary>
-        /// <param name="parameterString"></param>
-        /// <returns>an array of parsed parameters</returns>
-        private static string[] ParseXmlParameters(string parameterString)
-        {
-            var newParameterList = new List<string>();
-            var nestCount = 0;
-            var startIdx = 0;
-            for (int i = 0; i < parameterString.Length; i++)
-            {
-                if (parameterString[i] == ',' && nestCount == 0)
-                {
-                    newParameterList.Add(parameterString.Substring(startIdx, i - startIdx));
-                    startIdx = i + 1;
-                }
-                else if (i == parameterString.Length - 1)
-                {
-                    newParameterList.Add(parameterString.Substring(startIdx, parameterString.Length - startIdx));
-                }
-                else if (parameterString[i] == '[' || parameterString[i] == '{')
-                {
-                    nestCount++;
-                }
-                else if (parameterString[i] == ']' || parameterString[i] == '}')
-                {
-                    nestCount--;
-                }
-            }
-
-            return newParameterList.ToArray();
-        }
+              MemberName = match.Groups[3].Value,
+              Parameters = parameters,
+            };
+          }).Where(x => x != null)
+      .ToArray();
     }
+
+    private static int ParseParamType(string value, string[] tokens, int currIndex, List<string> newTypes)
+    {
+      var paramType = value;
+      if (paramType.Contains("{"))
+      {
+        var index = paramType.IndexOf("{");
+        var newType = paramType.Substring(0, index);
+        var nextType = paramType.Substring(index + 1, paramType.Length - index - 1);
+
+        List<string> innerTypes = new List<string>();
+        currIndex = ParseParamType(nextType, tokens, currIndex, innerTypes);
+        if (currIndex < tokens.Length && !nextType.Contains("}"))
+        {
+          do
+          {
+            paramType = tokens[currIndex];
+            currIndex = ParseParamType(paramType, tokens, currIndex, innerTypes);
+          }
+          while (!paramType.Contains("}") && currIndex < tokens.Length);
+        }
+
+        var innerTypeValue = string.Join(",", innerTypes);
+
+        newTypes.Add($"{newType}{{{innerTypeValue}}}");
+      }
+      else if (paramType.Contains("}"))
+      {
+        newTypes.Add(paramType.Replace("}", ""));
+        currIndex++;
+      }
+      else
+      {
+        newTypes.Add(paramType);
+        currIndex++;
+      }
+
+      return currIndex;
+    }
+
+    public static string ResolveSeeElement(Match m, string ns)
+    {
+      var typeNameMatch = Regex.Match(m.Groups[0].Value, "\"[^\"]*\"");
+      var typeName = typeNameMatch.Groups[0].Value.Replace("\"", "");
+
+      typeName = Cleaner.CleanName(typeName, true, false);
+
+      string returned;
+
+      // exceptions
+      if (typeName.Equals("T:System.Drawing.RectangleF"))
+      {
+        returned = $"[{typeName.Split('.').Last()}]" + "(https://docs.microsoft.com/en-us/dotnet/api/System.Drawing.RectangleF)";
+        return returned;
+      }
+
+      if (typeName.Equals("T:System.Collections.Generic.KeyNotFoundException"))
+      {
+        returned = $"[{typeName.Split('.').Last()}]" + "(https://docs.microsoft.com/en-us/dotnet/api/System.Collections.Generic.KeyNotFoundException-1)";
+        return returned;
+      }
+
+      var displayName = $"[{typeName.Split('.').Last()}]";
+      var baseLink = "(https://github.com/hargitomi97/sigstat/blob/master/docs/md/";
+      string linkPath;
+      if (typeName.StartsWith("F") || typeName.StartsWith("P") || typeName.StartsWith("E"))
+      {
+        linkPath = typeName.Replace('.', '/').Substring(typeName.IndexOf(":") + 1) + ")";
+        linkPath = linkPath.Substring(0, linkPath.LastIndexOf("/")) + ".md)";
+        returned = displayName + baseLink + linkPath;
+      }
+      else
+      {
+        linkPath = typeName.Replace('.', '/').Substring(typeName.IndexOf(":") + 1) + ".md)";
+        returned = displayName + baseLink + linkPath;
+      }
+
+      return returned;
+    }
+
+    public class Item1EqualityCompaerer<T1, T2> : EqualityComparer<Tuple<T1, T2>>
+    {
+      public override bool Equals(Tuple<T1, T2> x, Tuple<T1, T2> y)
+      {
+        return x.Item1.Equals(y.Item1);
+      }
+
+      public override int GetHashCode(Tuple<T1, T2> obj)
+      {
+        return obj.Item1.GetHashCode();
+      }
+    }
+
+    /// <summary>
+    /// Parse Xml Parameters with support from C# Discord and Nox#8248
+    /// </summary>
+    /// <param name="parameterString"></param>
+    /// <returns>an array of parsed parameters</returns>
+    public static string[] ParseXmlParameters(string parameterString)
+    {
+      var newParameterList = new List<string>();
+      var nestCount = 0;
+      var startIdx = 0;
+      for (int i = 0; i < parameterString.Length; i++)
+      {
+        if (parameterString[i] == ',' && nestCount == 0)
+        {
+          newParameterList.Add(parameterString.Substring(startIdx, i - startIdx));
+          startIdx = i + 1;
+        }
+        else if (i == parameterString.Length - 1)
+        {
+          newParameterList.Add(parameterString.Substring(startIdx, parameterString.Length - startIdx));
+        }
+        else if (parameterString[i] == '[' || parameterString[i] == '{')
+        {
+          nestCount++;
+        }
+        else if (parameterString[i] == ']' || parameterString[i] == '}')
+        {
+          nestCount--;
+        }
+      }
+
+      return newParameterList.ToArray();
+    }
+
+  }
 }

--- a/src/MarkdownApi.Core/Extensions.cs
+++ b/src/MarkdownApi.Core/Extensions.cs
@@ -1,4 +1,4 @@
-﻿using igloo15.MarkdownApi.Core.Builders;
+using igloo15.MarkdownApi.Core.Builders;
 using igloo15.MarkdownApi.Core.Interfaces;
 using igloo15.MarkdownApi.Core.MarkdownItems;
 using igloo15.MarkdownApi.Core.MarkdownItems.TypeParts;
@@ -8,348 +8,356 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Xml;
 
 namespace igloo15.MarkdownApi.Core
 {
-    internal static class Extensions
+  internal static class Extensions
+  {
+    public static T As<T>(this IMarkdownItem item) where T : class
     {
-        public static T As<T>(this IMarkdownItem item) where T : class
-        {
-            return item as T;
-        }
-
-        public static IEnumerable<T> Foreach<T>(this IEnumerable<T> array, Action<T> doThis)
-        {
-            foreach (var item in array)
-            {
-                doThis(item);
-            }
-
-            return array;
-        }
-
-        public static IEnumerable<T> Together<T>(this IEnumerable<T> arrayOne, IEnumerable<T> arrayTwo)
-        {
-            foreach (var itemOne in arrayOne)
-            {
-                yield return itemOne;
-            }
-
-            foreach (var itemTwo in arrayTwo)
-            {
-                yield return itemTwo;
-            }
-        }
-
-        public static string CombinePath(this string item1, params string[] items)
-        {
-            if (String.IsNullOrEmpty(item1))
-                return String.Join(Constants.PathSeparator.ToString(), items);
-
-            return item1 + String.Join(Constants.PathSeparator.ToString(), items);
-        }
-
-        public static string AddRoot(this string item)
-        {
-            return item.Prepend("." + Constants.PathSeparator);
-        }
-
-        public static string Prepend(this string item, string prependValue)
-        {
-            return prependValue + item;
-        }
-
-        public static string UpdatedRelativePath(this string fromPath, string toPath)
-        {
-            if (fromPath == toPath)
-                return "";
-
-            string[] fromDirs = fromPath.Split(new[] { Constants.PathSeparator, Path.DirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries);
-            string[] toDirs = toPath.Split(new[] { Constants.PathSeparator, Path.DirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries);
-
-            int len = Math.Min(fromDirs.Length, toDirs.Length);
-
-            int index = 0;
-            int lastCommonRoot = -1;
-
-            for (index = 0; index < len; index++)
-            {
-                if (fromDirs[index] == toDirs[index]) lastCommonRoot = index;
-                else break;
-            }
-
-            if (lastCommonRoot == -1)
-            {
-                throw new ArgumentException("Paths do not have a common base");
-            }
-
-            StringBuilder sb = new StringBuilder();
-
-            var fromDelta = fromDirs.Length - lastCommonRoot;
-            var toDelta = toDirs.Length - lastCommonRoot;
-
-            for (var i = 1; i < fromDelta; i++)
-            {
-                sb.Append($"..{Constants.PathSeparator}");
-            }
-
-            for (var i = 1; i < toDelta; i++)
-            {
-                sb.Append(toDirs[lastCommonRoot + i]).Append(Constants.PathSeparator);
-            }
-
-            return sb.ToString();
-        }
-
-        public static string RelativePath(this string absPath, string relTo)
-        {
-            if (absPath == relTo)
-                return "";
-
-            string[] absDirs = absPath.Split(Constants.PathSeparator, Path.DirectorySeparatorChar);
-            string[] relDirs = relTo.Split(Constants.PathSeparator, Path.DirectorySeparatorChar);
-
-            // Get the shortest of the two paths
-            int len = absDirs.Length < relDirs.Length ? absDirs.Length :
-            relDirs.Length;
-
-            // Use to determine where in the loop we exited
-            int lastCommonRoot = -1;
-            int index;
-
-            // Find common root
-            for (index = 0; index < len; index++)
-            {
-                if (absDirs[index] == relDirs[index]) lastCommonRoot = index;
-                else break;
-            }
-
-            // If we didn't find a common prefix then throw
-            if (lastCommonRoot == -1)
-            {
-                throw new ArgumentException("Paths do not have a common base");
-            }
-
-            // Build up the relative path
-            StringBuilder relativePath = new StringBuilder();
-
-            // Add on the ..
-            for (index = lastCommonRoot + 1; index < absDirs.Length; index++)
-            {
-                if (absDirs[index].Length > 0) relativePath.Append($"..{Constants.PathSeparator}");
-            }
-
-            // Add on the folders
-            for (index = lastCommonRoot + 1; index < relDirs.Length - 1; index++)
-            {
-                relativePath.Append(relDirs[index] + Constants.PathSeparator);
-            }
-            //relativePath.Append(relDirs[relDirs.Length - 1]);
-
-            return relativePath.ToString();
-        }
-
-        public static string GetId(this MemberInfo info)
-        {
-            return $"{info.Module.MetadataToken}-{info.MetadataToken}";
-        }
-
-        public static string GetCommentTypeString(this Type info)
-        {
-            var typeName = info.ToString().Replace("&", "@");
-            if (info.GenericTypeArguments.Length > 0)
-            {
-                var indexDash = typeName.IndexOf('`');
-                typeName = typeName.Substring(0, indexDash);
-                string genericTypeString = "";
-                for (var i = 0; i < info.GenericTypeArguments.Length; i++)
-                {
-                    var genericType = info.GenericTypeArguments[i];
-                    genericTypeString += genericType.GetCommentTypeString();
-                    if (i + 1 != info.GenericTypeArguments.Length)
-                        genericTypeString += ",";
-                }
-                typeName += $"{{{genericTypeString}}}";
-            }
-
-            if (info.IsGenericParameter)
-            {
-                typeName = $"``{info.GenericParameterPosition}";
-            }
-            else if (info.IsArray)
-            {
-                var elementType = info.GetElementType();
-                if (elementType.IsGenericParameter)
-                {
-                    typeName = typeName.Replace(elementType.ToString(), elementType.GetCommentTypeString());
-                    //typeName = $"``{info.GetElementType().GenericParameterPosition}[]";
-                }
-                else if (IsNullableType(elementType))
-                {
-                    typeName = typeName.Replace(elementType.ToString(), elementType.GetCommentTypeString());
-                }
-            }
-
-            return typeName;
-        }
-
-        public static string GetGenericType(this string typeName)
-        {
-            var indexDash = typeName.IndexOf('`');
-            typeName = typeName.Substring(0, indexDash);
-            return typeName;
-        }
-
-        public static bool IsNullableType(this Type info)
-        {
-            return Nullable.GetUnderlyingType(info) != null;
-        }
-
-        public static string GetCommentName(this MethodBase info)
-        {
-            if (info.IsGenericMethod)
-            {
-                return $"{info.Name}``{info.GetGenericArguments().Count()}";
-            }
-
-            if (info.Name.StartsWith("."))
-                return info.Name.Replace(".", "#");
-
-            return $"{info.Name}";
-        }
-
-        public static bool IsMatchOnMethod(this MethodBase methodInfo, XmlDocumentComment comment)
-        {
-            var isCorrectType = comment.MemberName == methodInfo.GetCommentName();
-
-            if (isCorrectType)
-            {
-                if (methodInfo.GetParameters().Count() == comment.Parameters.Count())
-                {
-                    var result = methodInfo.GetParameters().All(b => comment.Parameters.ContainsKey(b.Name + ":" + b.ParameterType.GetCommentTypeString()));
-                    if (result)
-                        return result;
-
-                    return methodInfo.GetParameters().All(b => comment.Parameters.ContainsKey(b.Name));
-                }
-            }
-
-            return false;
-            return false;
-        }
-
-        #region GetTypeParts
-
-        public static MarkdownConstructor[] GetConstructors(this MarkdownType mdType)
-        {
-            return mdType.InternalType.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
-                .Where(x => x.FilterMemberInfo() && !x.IsPrivate)
-                .Select(mi => new MarkdownConstructor(mi, mi.IsStatic))
-                .ToArray();
-        }
-
-        public static MarkdownConstructor[] GetStaticConstructors(this MarkdownType mdType)
-        {
-            return mdType.InternalType.GetConstructors(BindingFlags.Public | BindingFlags.Static)
-                .Where(x => x.FilterMemberInfo() && !x.IsPrivate)
-                .Select(mi => new MarkdownConstructor(mi, mi.IsStatic))
-                .ToArray();
-        }
-
-        public static MarkdownMethod[] GetMethods(this MarkdownType mdType)
-        {
-            return mdType.InternalType.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly | BindingFlags.InvokeMethod)
-                .Where(x => !x.IsSpecialName && x.FilterMemberInfo() && !x.IsPrivate)
-                .Select(mi => new MarkdownMethod(mi, false))
-                .ToArray();
-        }
-
-        public static MarkdownMethod[] GetStaticMethods(this MarkdownType mdType)
-        {
-            return mdType.InternalType.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly | BindingFlags.InvokeMethod)
-                .Where(x => !x.IsSpecialName && x.FilterMemberInfo() && !x.IsPrivate)
-                .Select(mi => new MarkdownMethod(mi, true))
-                .ToArray();
-        }
-
-        public static MarkdownProperty[] GetProperties(this MarkdownType mdType)
-        {
-            return mdType.InternalType.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly | BindingFlags.GetProperty | BindingFlags.SetProperty)
-                .Where(x => !x.IsSpecialName && x.FilterMemberInfo())
-                .Where(y => y.FilterPropertyInfo())
-                .Select(pi => new MarkdownProperty(pi, false))
-                .ToArray();
-        }
-
-        public static MarkdownProperty[] GetStaticProperties(this MarkdownType mdType)
-        {
-            return mdType.InternalType.GetProperties(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly | BindingFlags.GetProperty | BindingFlags.SetProperty)
-                .Where(x => !x.IsSpecialName && x.FilterMemberInfo())
-                .Where(y => y.FilterPropertyInfo())
-                .Select(pi => new MarkdownProperty(pi, true))
-                .ToArray();
-        }
-
-        public static MarkdownField[] GetFields(this MarkdownType mdType)
-        {
-            return mdType.InternalType.GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly | BindingFlags.GetField | BindingFlags.SetField)
-                .Where(x => !x.IsSpecialName && x.FilterMemberInfo() && !x.IsPrivate)
-                .Select(fi => new MarkdownField(fi, false))
-                .ToArray();
-        }
-
-        public static MarkdownField[] GetStaticFields(this MarkdownType mdType)
-        {
-            return mdType.InternalType.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly | BindingFlags.GetField | BindingFlags.SetField)
-                .Where(x => !x.IsSpecialName && x.FilterMemberInfo() && !x.IsPrivate)
-                .Select(fi => new MarkdownField(fi, true))
-                .ToArray();
-        }
-
-        public static MarkdownEvent[] GetEvents(this MarkdownType mdType)
-        {
-            return mdType.InternalType.GetEvents(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-                .Where(x => !x.IsSpecialName && x.FilterMemberInfo())
-                .Select(ei => new MarkdownEvent(ei, false))
-                .ToArray();
-        }
-
-        public static MarkdownEvent[] GetStaticEvents(this MarkdownType mdType)
-        {
-            return mdType.InternalType.GetEvents(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
-                .Where(x => !x.IsSpecialName && x.FilterMemberInfo())
-                .Select(ei => new MarkdownEvent(ei, true))
-                .ToArray();
-        }
-
-        private static bool FilterMemberInfo(this MemberInfo info)
-        {
-            return !info.GetCustomAttributes<ObsoleteAttribute>().Any();
-        }
-
-        private static bool FilterPropertyInfo(this PropertyInfo info)
-        {
-            var get = info.GetGetMethod(true);
-            var set = info.GetSetMethod(true);
-            if (get != null && set != null)
-            {
-                return !(get.IsPrivate && set.IsPrivate);
-            }
-            else if (get != null)
-            {
-                return !get.IsPrivate;
-            }
-            else if (set != null)
-            {
-                return !set.IsPrivate;
-            }
-            else
-            {
-                return false;
-            }
-        }
-
-        #endregion GetTypeParts
+      return item as T;
     }
+
+    public static IEnumerable<T> Foreach<T>(this IEnumerable<T> array, Action<T> doThis)
+    {
+      foreach (var item in array)
+      {
+        doThis(item);
+      }
+
+      return array;
+    }
+
+    public static IEnumerable<T> Together<T>(this IEnumerable<T> arrayOne, IEnumerable<T> arrayTwo)
+    {
+      foreach (var itemOne in arrayOne)
+      {
+        yield return itemOne;
+      }
+
+      foreach (var itemTwo in arrayTwo)
+      {
+        yield return itemTwo;
+      }
+    }
+
+    public static string CombinePath(this string item1, params string[] items)
+    {
+      if (String.IsNullOrEmpty(item1))
+        return String.Join(Constants.PathSeparator.ToString(), items);
+
+      return item1 + String.Join(Constants.PathSeparator.ToString(), items);
+    }
+
+    public static string AddRoot(this string item)
+    {
+      return item.Prepend("." + Constants.PathSeparator);
+    }
+
+    public static string Prepend(this string item, string prependValue)
+    {
+      return prependValue + item;
+    }
+
+    public static string UpdatedRelativePath(this string fromPath, string toPath)
+    {
+      if (fromPath == toPath)
+        return "";
+
+      string[] fromDirs = fromPath.Split(new[] { Constants.PathSeparator, Path.DirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries);
+      string[] toDirs = toPath.Split(new[] { Constants.PathSeparator, Path.DirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries);
+
+      int len = Math.Min(fromDirs.Length, toDirs.Length);
+
+      int index = 0;
+      int lastCommonRoot = -1;
+
+      for (index = 0; index < len; index++)
+      {
+        if (fromDirs[index] == toDirs[index]) lastCommonRoot = index;
+        else break;
+      }
+
+      if (lastCommonRoot == -1)
+      {
+        throw new ArgumentException("Paths do not have a common base");
+      }
+
+      StringBuilder sb = new StringBuilder();
+
+      var fromDelta = fromDirs.Length - lastCommonRoot;
+      var toDelta = toDirs.Length - lastCommonRoot;
+
+      for (var i = 1; i < fromDelta; i++)
+      {
+        sb.Append($"..{Constants.PathSeparator}");
+      }
+
+      for (var i = 1; i < toDelta; i++)
+      {
+        sb.Append(toDirs[lastCommonRoot + i]).Append(Constants.PathSeparator);
+      }
+
+      return sb.ToString();
+    }
+
+    public static string RelativePath(this string absPath, string relTo)
+    {
+      if (absPath == relTo)
+        return "";
+
+      string[] absDirs = absPath.Split(Constants.PathSeparator, Path.DirectorySeparatorChar);
+      string[] relDirs = relTo.Split(Constants.PathSeparator, Path.DirectorySeparatorChar);
+
+      // Get the shortest of the two paths
+      int len = absDirs.Length < relDirs.Length ? absDirs.Length :
+      relDirs.Length;
+
+      // Use to determine where in the loop we exited
+      int lastCommonRoot = -1;
+      int index;
+
+      // Find common root
+      for (index = 0; index < len; index++)
+      {
+        if (absDirs[index] == relDirs[index]) lastCommonRoot = index;
+        else break;
+      }
+
+      // If we didn't find a common prefix then throw
+      if (lastCommonRoot == -1)
+      {
+        throw new ArgumentException("Paths do not have a common base");
+      }
+
+      // Build up the relative path
+      StringBuilder relativePath = new StringBuilder();
+
+      // Add on the ..
+      for (index = lastCommonRoot + 1; index < absDirs.Length; index++)
+      {
+        if (absDirs[index].Length > 0) relativePath.Append($"..{Constants.PathSeparator}");
+      }
+
+      // Add on the folders
+      for (index = lastCommonRoot + 1; index < relDirs.Length - 1; index++)
+      {
+        relativePath.Append(relDirs[index] + Constants.PathSeparator);
+      }
+      //relativePath.Append(relDirs[relDirs.Length - 1]);
+
+      return relativePath.ToString();
+    }
+
+    public static string GetId(this MemberInfo info)
+    {
+      return $"{info.Module.MetadataToken}-{info.MetadataToken}";
+    }
+
+    public static string GetCommentTypeString(this Type info)
+    {
+      var typeName = info.ToString().Replace("&", "@");
+      if (info.GenericTypeArguments.Length > 0)
+      {
+        var indexDash = typeName.IndexOf('`');
+        typeName = typeName.Substring(0, indexDash);
+        string genericTypeString = "";
+        for (var i = 0; i < info.GenericTypeArguments.Length; i++)
+        {
+          var genericType = info.GenericTypeArguments[i];
+          genericTypeString += genericType.GetCommentTypeString();
+          if (i + 1 != info.GenericTypeArguments.Length)
+            genericTypeString += ",";
+        }
+        typeName += $"{{{genericTypeString}}}";
+      }
+
+      if (info.IsGenericParameter)
+      {
+        typeName = $"``{info.GenericParameterPosition}";
+      }
+      else if (info.IsArray)
+      {
+        var elementType = info.GetElementType();
+        if (elementType.IsGenericParameter)
+        {
+          typeName = typeName.Replace(elementType.ToString(), elementType.GetCommentTypeString());
+          //typeName = $"``{info.GetElementType().GenericParameterPosition}[]";
+        }
+        else if (IsNullableType(elementType))
+        {
+          typeName = typeName.Replace(elementType.ToString(), elementType.GetCommentTypeString());
+        }
+      }
+
+      return typeName;
+    }
+
+    public static string GetGenericType(this string typeName)
+    {
+      var indexDash = typeName.IndexOf('`');
+      typeName = typeName.Substring(0, indexDash);
+      return typeName;
+    }
+
+    public static bool IsNullableType(this Type info)
+    {
+      return Nullable.GetUnderlyingType(info) != null;
+    }
+
+    public static string GetCommentName(this MethodBase info)
+    {
+      if (info.IsGenericMethod)
+      {
+        return $"{info.Name}``{info.GetGenericArguments().Count()}";
+      }
+
+      if (info.Name.StartsWith("."))
+        return info.Name.Replace(".", "#");
+
+      return $"{info.Name}";
+    }
+    public static int IndexOfNth(this string str, string value, int nth = 1)
+    {
+      if (nth <= 0)
+        throw new ArgumentException("Can not find the zeroth index of substring in string. Must start with 1");
+      int offset = str.IndexOf(value);
+      for (int i = 1; i < nth; i++)
+      {
+        if (offset == -1) return -1;
+        offset = str.IndexOf(value, offset + 1);
+      }
+      return offset;
+    }
+
+    public static bool IsMatchOnMethod(this MethodBase methodInfo, XmlDocumentComment comment)
+    {
+      var isCorrectType = comment.MemberName == methodInfo.GetCommentName();
+
+      if (isCorrectType)
+      {
+        if (methodInfo.GetParameters().Count() == comment.Parameters.Count())
+        {
+          var result = methodInfo.GetParameters().All(b => comment.Parameters.ContainsKey(b.Name + ":" + b.ParameterType.GetCommentTypeString()));
+          if (result)
+            return result;
+
+          return methodInfo.GetParameters().All(b => comment.Parameters.ContainsKey(b.Name));
+        }
+      }
+
+      return false;
+    }
+
+    #region GetTypeParts
+    public static MarkdownConstructor[] GetConstructors(this MarkdownType mdType)
+    {
+      return mdType.InternalType.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+          .Where(x => x.FilterMemberInfo() && !x.IsPrivate)
+          .Select(mi => new MarkdownConstructor(mi, mi.IsStatic))
+          .ToArray();
+    }
+
+    public static MarkdownConstructor[] GetStaticConstructors(this MarkdownType mdType)
+    {
+      return mdType.InternalType.GetConstructors(BindingFlags.Public | BindingFlags.Static)
+          .Where(x => x.FilterMemberInfo() && !x.IsPrivate)
+          .Select(mi => new MarkdownConstructor(mi, mi.IsStatic))
+          .ToArray();
+    }
+
+    public static MarkdownMethod[] GetMethods(this MarkdownType mdType)
+    {
+      return mdType.InternalType.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly | BindingFlags.InvokeMethod)
+          .Where(x => !x.IsSpecialName && x.FilterMemberInfo() && !x.IsPrivate)
+          .Select(mi => new MarkdownMethod(mi, false))
+          .ToArray();
+    }
+
+    public static MarkdownMethod[] GetStaticMethods(this MarkdownType mdType)
+    {
+      return mdType.InternalType.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly | BindingFlags.InvokeMethod)
+          .Where(x => !x.IsSpecialName && x.FilterMemberInfo() && !x.IsPrivate)
+          .Select(mi => new MarkdownMethod(mi, true))
+          .ToArray();
+    }
+
+    public static MarkdownProperty[] GetProperties(this MarkdownType mdType)
+    {
+      return mdType.InternalType.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly | BindingFlags.GetProperty | BindingFlags.SetProperty)
+          .Where(x => !x.IsSpecialName && x.FilterMemberInfo())
+          .Where(y => y.FilterPropertyInfo())
+          .Select(pi => new MarkdownProperty(pi, false))
+          .ToArray();
+    }
+
+    public static MarkdownProperty[] GetStaticProperties(this MarkdownType mdType)
+    {
+      return mdType.InternalType.GetProperties(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly | BindingFlags.GetProperty | BindingFlags.SetProperty)
+          .Where(x => !x.IsSpecialName && x.FilterMemberInfo())
+          .Where(y => y.FilterPropertyInfo())
+          .Select(pi => new MarkdownProperty(pi, true))
+          .ToArray();
+    }
+
+    public static MarkdownField[] GetFields(this MarkdownType mdType)
+    {
+      return mdType.InternalType.GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly | BindingFlags.GetField | BindingFlags.SetField)
+          .Where(x => !x.IsSpecialName && x.FilterMemberInfo() && !x.IsPrivate)
+          .Select(fi => new MarkdownField(fi, false))
+          .ToArray();
+    }
+
+    public static MarkdownField[] GetStaticFields(this MarkdownType mdType)
+    {
+      return mdType.InternalType.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly | BindingFlags.GetField | BindingFlags.SetField)
+          .Where(x => !x.IsSpecialName && x.FilterMemberInfo() && !x.IsPrivate)
+          .Select(fi => new MarkdownField(fi, true))
+          .ToArray();
+    }
+
+    public static MarkdownEvent[] GetEvents(this MarkdownType mdType)
+    {
+      return mdType.InternalType.GetEvents(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+          .Where(x => !x.IsSpecialName && x.FilterMemberInfo())
+          .Select(ei => new MarkdownEvent(ei, false))
+          .ToArray();
+    }
+
+    public static MarkdownEvent[] GetStaticEvents(this MarkdownType mdType)
+    {
+      return mdType.InternalType.GetEvents(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+          .Where(x => !x.IsSpecialName && x.FilterMemberInfo())
+          .Select(ei => new MarkdownEvent(ei, true))
+          .ToArray();
+    }
+
+    private static bool FilterMemberInfo(this MemberInfo info)
+    {
+      return !info.GetCustomAttributes<ObsoleteAttribute>().Any();
+    }
+
+    private static bool FilterPropertyInfo(this PropertyInfo info)
+    {
+      var get = info.GetGetMethod(true);
+      var set = info.GetSetMethod(true);
+      if (get != null && set != null)
+      {
+        return !(get.IsPrivate && set.IsPrivate);
+      }
+      else if (get != null)
+      {
+        return !get.IsPrivate;
+      }
+      else if (set != null)
+      {
+        return !set.IsPrivate;
+      }
+      else
+      {
+        return false;
+      }
+    }
+    #endregion
+  }
 }

--- a/src/MarkdownApi.Core/MarkdownItems/TypeParts/MarkdownMethod.cs
+++ b/src/MarkdownApi.Core/MarkdownItems/TypeParts/MarkdownMethod.cs
@@ -1,4 +1,4 @@
-﻿using igloo15.MarkdownApi.Core.Interfaces;
+using igloo15.MarkdownApi.Core.Interfaces;
 using System;
 using System.Reflection;
 
@@ -54,6 +54,11 @@ namespace igloo15.MarkdownApi.Core.MarkdownItems.TypeParts
         /// </summary>
         public bool IsOverriden => BaseDefinition != InternalItem.DeclaringType;
 
+        /// <summary>
+        /// Gets the parameters of this method
+        /// </summary>
+        public ParameterInfo[] Parameters => InternalItem.GetParameters();
+
         internal MarkdownMethod(MethodInfo info, bool isStatic)
         {
             InternalItem = info;
@@ -69,6 +74,7 @@ namespace igloo15.MarkdownApi.Core.MarkdownItems.TypeParts
         {
             return theme.BuildPage(this);
         }
+
 
         /// <summary>
         /// The type info of the MarkdownItem used to find references to it from other MarkdownItems

--- a/src/MarkdownApi.Core/Themes/Default/Cleaner.cs
+++ b/src/MarkdownApi.Core/Themes/Default/Cleaner.cs
@@ -1,4 +1,4 @@
-﻿using igloo15.MarkdownApi.Core.Builders;
+using igloo15.MarkdownApi.Core.Builders;
 using igloo15.MarkdownApi.Core.Interfaces;
 using igloo15.MarkdownApi.Core.MarkdownItems.TypeParts;
 using System;
@@ -24,7 +24,7 @@ namespace igloo15.MarkdownApi.Core.Themes.Default
         {
             StringBuilder sb = new StringBuilder();
             var genericArray = target.GetGenericArguments();
-            for(var i = 0; i < genericArray.Length; i++)
+            for (var i = 0; i < genericArray.Length; i++)
             {
                 var link = CreateFullTypeWithLinks(currentItem, genericArray[i], useFullName, useSpecialText);
                 sb.Append(link);
@@ -35,7 +35,7 @@ namespace igloo15.MarkdownApi.Core.Themes.Default
 
             var actualName = currentItem.GetNameOrNameLink(target, useFullName, useSpecialText);
 
-            if(genericArray.Length > 0)
+            if (genericArray.Length > 0)
                 return $"{actualName}\\<{sb.ToString()}>";
             return actualName;
         }
@@ -89,21 +89,27 @@ namespace igloo15.MarkdownApi.Core.Themes.Default
         /// <param name="method">The method to be cleaned</param>
         /// <param name="useFullName">Determine if full name of method should be shown</param>
         /// <param name="useParameterNames">Determines if parameter names should be shown</param>
+        /// <param name="parameterList">Determines if parameter names should be listed vertically</param>
         /// <returns>The cleaned string</returns>
-        public static string CreateFullMethodWithLinks(IMarkdownItem currentItem, MarkdownMethod method, bool useFullName, bool useParameterNames)
+        public static string CreateFullMethodWithLinks(IMarkdownItem currentItem, MarkdownMethod method, bool useFullName, bool useParameterNames, bool parameterList)
         {
             var parameters = method.InternalItem.GetParameters();
+           
             MarkdownBuilder mb = new MarkdownBuilder();
-            if (method.FileName != null)
-                mb.Link(method.Name, currentItem.To(method));
-            else
-                mb.Append(method.Name);
-            mb.Append(" ( ");
+
+            if (!parameterList)
+            {
+                if (method.FileName != null)
+                    mb.Link(method.Name, currentItem.To(method));
+                else
+                    mb.Append(method.Name);
+                mb.Append(" ( ");
+            }
             if (parameters.Length > 0)
             {
-                
+
                 StringBuilder sb = new StringBuilder();
-                for(var i = 0; i < parameters.Length; i++)
+                for (var i = 0; i < parameters.Length; i++)
                 {
                     var type = parameters[i].ParameterType;
                     var link = CreateFullTypeWithLinks(currentItem, type, useFullName, true);
@@ -113,21 +119,42 @@ namespace igloo15.MarkdownApi.Core.Themes.Default
                         link = link.Replace("&", "");
                         sb.Append("out ");
                     }
+                   
 
-                    sb.Append(link);
+                    if (!parameterList)
+                    {
+                        sb.Append(link);
 
-                    if(useParameterNames)
-                        sb.Append($" {parameters[i].Name}");
+                        if (useParameterNames)
+                            sb.Append($" {parameters[i].Name}");
+                    }
+                    else
+                    {
+                        if (useParameterNames)
+                            sb.Append($" {parameters[i].Name}");
 
-                    
-                        
+                        sb.Append(link);
+                    }
 
-                    if (i + 1 != parameters.Length)
-                        sb.Append(", ");
+                    if (!parameterList)
+                    {
+                        if (i + 1 != parameters.Length)
+                        {
+                            sb.Append(", ");
+                        }
+                    }
+                    else
+                    {
+                        if (i + 1 != parameters.Length)
+                        {
+                            sb.Append("<br>");
+                        }
+                    }
                 }
                 mb.Append(sb.ToString());
             }
-            mb.Append(" )");
+            if (!parameterList)
+                mb.Append(" )");
             return mb.ToString();
         }
 
@@ -165,7 +192,7 @@ namespace igloo15.MarkdownApi.Core.Themes.Default
 
                 mb.Append(" ]");
             }
-            
+
             return mb.ToString();
         }
 
@@ -180,7 +207,7 @@ namespace igloo15.MarkdownApi.Core.Themes.Default
                     {
                         return (param.ParameterType, param.Name);
                     }
-                        
+
                 }
 
             }
@@ -204,7 +231,7 @@ namespace igloo15.MarkdownApi.Core.Themes.Default
 
             var name = t.FullName;
 
-            return CleanName(t.FullName, keepGenericNumber, specialText);            
+            return CleanName(t.FullName, keepGenericNumber, specialText);
         }
 
         /// <summary>
@@ -266,5 +293,16 @@ namespace igloo15.MarkdownApi.Core.Themes.Default
             return RemoveGenerics(name);
         }
 
+        /// <summary>
+        /// Display the bold version of the string
+        /// </summary>
+        /// <param name="name">The name</param>
+        /// <returns></returns>
+        public static string BoldName(string name)
+        {
+            if (String.IsNullOrEmpty(name))
+                return name;
+            return $"**`{ name }`**";
+        }
     }
 }

--- a/src/MarkdownApi.Core/Themes/Default/DefaultEnumBuilder.cs
+++ b/src/MarkdownApi.Core/Themes/Default/DefaultEnumBuilder.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace igloo15.MarkdownApi.Core.Themes.Default
 {
@@ -92,7 +91,7 @@ namespace igloo15.MarkdownApi.Core.Themes.Default
                     };
                 });
 
-                mb.Table(head, data);
+                mb.Table(head, data, true);
                 mb.AppendLine();
             }
         }

--- a/src/MarkdownApi.Core/Themes/Default/DefaultMethodBuilder.cs
+++ b/src/MarkdownApi.Core/Themes/Default/DefaultMethodBuilder.cs
@@ -1,35 +1,213 @@
-﻿using igloo15.MarkdownApi.Core.Builders;
+using igloo15.MarkdownApi.Core.Builders;
+using igloo15.MarkdownApi.Core.Interfaces;
 using igloo15.MarkdownApi.Core.MarkdownItems.TypeParts;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
 
 namespace igloo15.MarkdownApi.Core.Themes.Default
 {
+  /// <summary>
+  /// Default markdown method page builder - Warning this is not yet implemented
+  /// </summary>
+  public class DefaultMethodBuilder
+  {
+    private DefaultOptions _options;
+
+
     /// <summary>
-    /// Default markdown method page builder - Warning this is not yet implemented
+    /// Constructs a markdown method page builder
     /// </summary>
-    public class DefaultMethodBuilder
+    /// <param name="options">The default options to be constructed with</param>
+    public DefaultMethodBuilder(DefaultOptions options)
     {
-        private DefaultOptions _options;
+      _options = options;
+    }
 
-        /// <summary>
-        /// Constructs a markdown method page builder  - Warning this is not yet implemented
-        /// </summary>
-        /// <param name="options">The default options to be constructed with</param>
-        public DefaultMethodBuilder(DefaultOptions options)
+    /// <summary>
+    /// Builds the markdown method page content
+    /// </summary>
+    /// <param name="item">The markdown method item</param>
+    /// <returns>The markdown content</returns>
+    public string BuildPage(MarkdownMethod item)
+    {
+      Dictionary<string, string> parameterPairs = new Dictionary<string, string>();
+      Dictionary<string, string> returnPairs = new Dictionary<string, string>();
+      XmlDocumentComment[] comments = new XmlDocumentComment[0];
+
+      MarkdownBuilder mb = new MarkdownBuilder();
+
+
+      var name = Cleaner.CreateFullMethodWithLinks(item, item.As<MarkdownMethod>(), false, true, true);
+
+      // method name + params name with type
+      var FullName = item.Name + name;
+
+      var typeZeroHeaders = new[] { "Return", "Name" };
+
+
+      mb.HeaderWithLink(1, item.FullName, item.To(item));
+      mb.AppendLine();
+
+
+      mb.AppendLine(item.Summary);
+
+      BuildTable(mb, item, typeZeroHeaders, item);
+
+      mb.Append("#### Parameters");
+      mb.AppendLine();
+
+      if (File.Exists(MarkdownItemBuilder.xmlPath))
+      {
+        comments = VSDocParser.ParseXmlParameterComment(XDocument.Parse(File.ReadAllText(MarkdownItemBuilder.xmlPath)), "");
+
+        foreach (var comment in comments)
         {
-            _options = options;
-        }
+          foreach (var param in item.Parameters)
+          {
 
-        /// <summary>
-        /// Builds the markdown method page content - Warning this is not yet implemented
-        /// </summary>
-        /// <param name="item">The markdown method item</param>
-        /// <returns>The markdown content</returns>
-        public string BuildPage(MarkdownMethod item)
+            var foundParameterComment = comment.Parameters.FirstOrDefault(x => x.Key == param.Name).Value;
+            if (foundParameterComment != null)
+            {
+              foundParameterComment = foundParameterComment.Substring(0, foundParameterComment.LastIndexOf('<'));
+              foundParameterComment = foundParameterComment.Substring(foundParameterComment.IndexOf('>') + 1);
+
+              var MethodName = Cleaner.CleanName(comment.MemberName, false, false);
+
+              // method name + param name + parameter summary
+              if (!parameterPairs.ContainsKey(MethodName + " " + param.Name))
+                parameterPairs.Add(MethodName + " " + param.Name, foundParameterComment);
+            }
+          }
+        }
+      }
+
+      var numberOfParameters = item.Parameters.Length;
+
+      for(int i = 1; i<=numberOfParameters; i++)
+      {
+        if(i == numberOfParameters)
+        ConstructParameter(mb, FullName, parameterPairs, false, i);
+        else
         {
-            MarkdownBuilder mb = new MarkdownBuilder();
-
-            return mb.ToString();
+          ConstructParameter(mb, FullName, parameterPairs, true, i);
         }
+      }
+
+      mb.AppendLine();
+      mb.Append("#### Returns");
+      mb.AppendLine();
+
+      Type lookUpType = null;
+      if (item.ItemType == MarkdownItemTypes.Method)
+        lookUpType = item.As<MarkdownMethod>().ReturnType;
+      var returned = Cleaner.CreateFullTypeWithLinks(item, lookUpType, false, false);
+      string foundReturnComment = string.Empty;
+
+      if (File.Exists(MarkdownItemBuilder.xmlPath))
+      {
+        comments = VSDocParser.ParseXmlComment(XDocument.Parse(File.ReadAllText(MarkdownItemBuilder.xmlPath)), "");
+        if (comments != null)
+        {
+          foreach (var k in comments)
+          {
+            k.MemberName = Cleaner.CleanName(k.MemberName, false, false);
+            returnPairs[k.MemberName] = k.Returns;
+          }
+          foundReturnComment = returnPairs.FirstOrDefault(x => x.Key == item.Name).Value;
+        }
+      }
+      foundReturnComment = Regex.Replace(foundReturnComment, @"<see cref=""\w:([^\""]*)""\s*\/>", m => VSDocParser.ResolveSeeElement(m, ""));
+      mb.Append(returned);
+      mb.AppendLine("<br>");
+      mb.Append(foundReturnComment);
+
+      return mb.ToString();
 
     }
+
+    
+
+    private void ConstructParameter(MarkdownBuilder mb, string FullName, Dictionary<string, string> parameterPairs, bool breakLineIndex, int number)
+    {
+      var MethodName = FullName.Substring(0, FullName.IndexOf(" "));
+      var ParamName = string.Empty;
+      if (number == 1)
+      {
+        ParamName = FullName.Substring(FullName.IndexOf(" "));
+      }
+      else
+      {
+        int index = Extensions.IndexOfNth(FullName, "<br>", number-1);
+        ParamName = FullName.Substring(index + 4);
+      }
+
+      var ParameterTypeBegin = ParamName;
+      if(ParamName.IndexOf("[") > 0)
+      ParamName = ParamName.Substring(0, ParamName.IndexOf("[")).Trim();
+      var methodAndParamName = MethodName + " " + ParamName;
+      var ParameterComment = parameterPairs.FirstOrDefault(x => x.Key == methodAndParamName).Value;
+      var BreakLineIndex = 0;
+
+      if (ParameterComment != null)
+      {
+        ParamName = Cleaner.BoldName(ParamName);
+        
+        var ParameterType = ParameterTypeBegin.Substring(ParameterTypeBegin.IndexOf("["));
+        BreakLineIndex = ParameterType.IndexOf("<br>");
+        if (BreakLineIndex > 0)
+          ParameterType = ParameterType.Substring(0, BreakLineIndex);
+        ParameterComment = Regex.Replace(ParameterComment, @"<see cref=""\w:([^\""]*)""\s*\/>", m => VSDocParser.ResolveSeeElement(m, ""));
+        if (breakLineIndex)
+        {
+          mb.Append(ParamName + "  " + ParameterType + "<br>" + ParameterComment + "<br><br>");
+        }
+        else
+        {
+          mb.Append(ParamName + "  " + ParameterType + "<br>" + ParameterComment);
+        }
+      }
+    }
+
+    private void BuildTable(MarkdownBuilder mb, IMarkdownItem item, string[] headers, MarkdownMethod mdType)
+    {
+      mb.AppendLine();
+
+      List<string[]> data = new List<string[]>();
+
+
+      string[] dataValues = new string[headers.Length];
+
+      Type lookUpType = null;
+      if (item.ItemType == MarkdownItemTypes.Method)
+        lookUpType = item.As<MarkdownMethod>().ReturnType;
+
+      dataValues[0] = Cleaner.CreateFullTypeWithLinks(mdType, lookUpType, false, false);
+
+      string name = item.FullName;
+      if (item.ItemType == MarkdownItemTypes.Method)
+      {
+        name = Cleaner.CreateFullMethodWithLinks(mdType, item.As<MarkdownMethod>(), false, true, false);
+      }
+      else if (item.ItemType == MarkdownItemTypes.Property)
+      {
+        name = Cleaner.CreateFullParameterWithLinks(mdType, item.As<MarkdownProperty>(), false, _options.ShowParameterNames);
+      }
+      else if (item.ItemType == MarkdownItemTypes.Constructor)
+      {
+        name = Cleaner.CreateFullConstructorsWithLinks(mdType, item.As<MarkdownConstructor>(), false, _options.BuildConstructorPages);
+      }
+
+
+      dataValues[1] = name;
+
+      data.Add(dataValues);
+      mb.Table(headers, data, true);
+      mb.AppendLine();
+    }
+  }
 }
+

--- a/src/MarkdownApi.Core/Themes/Default/DefaultResolver.cs
+++ b/src/MarkdownApi.Core/Themes/Default/DefaultResolver.cs
@@ -1,4 +1,4 @@
-﻿using igloo15.MarkdownApi.Core.Interfaces;
+using igloo15.MarkdownApi.Core.Interfaces;
 using igloo15.MarkdownApi.Core.MarkdownItems;
 using igloo15.MarkdownApi.Core.MarkdownItems.TypeParts;
 using System.IO;
@@ -77,11 +77,11 @@ namespace igloo15.MarkdownApi.Core.Themes.Default
                     return null;
                 case MarkdownConstructor constructor:
                     if(_options.BuildConstructorPages)
-                        return $"{constructor.ParentType.Name}-{constructor.InternalItem.MetadataToken}.md";
+                        return $"{constructor.ParentType.Name}--{constructor.InternalItem.MetadataToken}.md";
                     return null;
                 case MarkdownMethod method:
-                    if(_options.BuildMethodPages)
-                        return $"{method.ParentType.Name}-{method.InternalItem.MetadataToken}.md";
+                    if (_options.BuildMethodPages)
+                        return $"{method.ParentType.Name}--{method.InternalItem.Name}.md";
                     return null;
             }
 

--- a/src/MarkdownApi.Core/Themes/Default/DefaultThemeExtensions.cs
+++ b/src/MarkdownApi.Core/Themes/Default/DefaultThemeExtensions.cs
@@ -1,17 +1,14 @@
-﻿using igloo15.MarkdownApi.Core.Builders;
+using igloo15.MarkdownApi.Core.Builders;
 using igloo15.MarkdownApi.Core.Interfaces;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Linq;
-using System.Reflection;
 
 namespace igloo15.MarkdownApi.Core.Themes.Default
 {
 
     internal static class DefaultThemeExtensions
     {
-        
+
         public static void BuildNamespaceLinks(this IMarkdownItem item, string namespaceValue, MarkdownBuilder mb)
         {
             var namespaceItems = namespaceValue.Split('.');
@@ -22,6 +19,7 @@ namespace igloo15.MarkdownApi.Core.Themes.Default
 
             foreach (var namespaceItem in namespaceItems)
             {
+
                 if (!String.IsNullOrEmpty(globalNamespace))
                 {
                     globalNamespace += ".";
@@ -50,11 +48,22 @@ namespace igloo15.MarkdownApi.Core.Themes.Default
             if (targetType == null)
                 return "";
             if (targetType == typeof(void))
-                return "void";
+                return "[Void]" + "(https://docs.microsoft.com/en-us/dotnet/api/System.Void)";
 
-            if (targetType.FullName == null && targetType.Name == null) 
+            if (targetType.FullName == null && targetType.Name == null)
                 return "";
-            
+
+            // exceptions
+            if (targetType.ToString().Equals("System.Collections.Generic.IEnumerable`1[T]") || targetType.ToString().Equals("System.Collections.Generic.IEnumerable`1[P]"))
+            {
+                return "[IEnumerable]" + "(https://docs.microsoft.com/en-us/dotnet/api/System.Collections.Ienumerable)";
+            }
+
+            if (targetType.ToString().Contains("System.Func`3"))
+            {
+                return "[Func]" + "(https://docs.microsoft.com/en-us/dotnet/api/System.Func-3)";
+            }
+
             string name = targetType.Name;
             string fullName = targetType.ToString();
 
@@ -67,7 +76,7 @@ namespace igloo15.MarkdownApi.Core.Themes.Default
 
             var link = currentType.GetLink(new TypeWrapper(targetType));
 
-            if(link != null)
+            if (link != null)
             {
                 tempMB.Link(name, link);
             }
@@ -78,18 +87,20 @@ namespace igloo15.MarkdownApi.Core.Themes.Default
 
             if (targetType.IsArray)
                 tempMB.Append("[]");
-            
+
             return tempMB.ToString();
         }
 
         public static string GetLink(this IMarkdownItem currentItem, TypeWrapper info)
         {
+
             if (currentItem.Project.TryGetValue(info, out IMarkdownItem lookupItem))
             {
                 return currentItem.To(lookupItem);
             }
-            else if (info.FullName.StartsWith("System"))
-            {
+            
+            else if (info.FullName.StartsWith("System") || info.FullName.StartsWith("Microsoft"))
+            {            
                 return "https://docs.microsoft.com/en-us/dotnet/api/" + Cleaner.CleanName(info.FullName, true, false);
             }
             return null;

--- a/src/MarkdownApi.Core/Themes/Default/DefaultTypeBuilder.cs
+++ b/src/MarkdownApi.Core/Themes/Default/DefaultTypeBuilder.cs
@@ -1,4 +1,4 @@
-﻿using igloo15.MarkdownApi.Core.Builders;
+using igloo15.MarkdownApi.Core.Builders;
 using igloo15.MarkdownApi.Core.Interfaces;
 using igloo15.MarkdownApi.Core.MarkdownItems;
 using igloo15.MarkdownApi.Core.MarkdownItems.TypeParts;
@@ -85,16 +85,15 @@ namespace igloo15.MarkdownApi.Core.Themes.Default
             BuildTable(mb, "Static Constructors", item.GetConstructors(true), typeZeroHeaders, item);
             BuildTable(mb, "Constructors", item.GetConstructors(false), typeZeroHeaders, item);
 
-            BuildTable(mb, "Fields", item.GetFields(false), typeOneHeaders, item);
-            BuildTable(mb, "Properties", item.GetProperties(false), typeOneHeaders, item);
-            BuildTable(mb, "Methods", item.GetMethods(false), typeTwoHeaders, item);
-            BuildTable(mb, "Events", item.GetEvents(false), typeOneHeaders, item);
+            BuildTable(mb, "Fields", item.GetFields(false), typeZeroHeaders, item);
+            BuildTable(mb, "Properties", item.GetProperties(false), typeZeroHeaders, item);
+            BuildTable(mb, "Methods", item.GetMethods(false), typeZeroHeaders, item);
+            BuildTable(mb, "Events", item.GetEvents(false), typeZeroHeaders, item);
 
-            BuildTable(mb, "Static Fields", item.GetFields(true), typeOneHeaders, item);
-            BuildTable(mb, "Static Properties", item.GetProperties(true), typeOneHeaders, item);
-            BuildTable(mb, "Static Methods", item.GetMethods(true), typeTwoHeaders, item);
-            BuildTable(mb, "Static Events", item.GetEvents(true), typeOneHeaders, item);
-
+            BuildTable(mb, "Static Fields", item.GetFields(true), typeZeroHeaders, item);
+            BuildTable(mb, "Static Properties", item.GetProperties(true), typeZeroHeaders, item);
+            BuildTable(mb, "Static Methods", item.GetMethods(true), typeZeroHeaders, item);
+            BuildTable(mb, "Static Events", item.GetEvents(true), typeZeroHeaders, item);
 
             return mb.ToString();
         }
@@ -132,13 +131,18 @@ namespace igloo15.MarkdownApi.Core.Themes.Default
                     if (item.ItemType == MarkdownItemTypes.Constructor)
                         dataValues[0] = Cleaner.CreateFullConstructorsWithLinks(mdType, item.As<MarkdownConstructor>(), false, _options.ShowParameterNames);
                     else
+                    {
                         dataValues[0] = Cleaner.CreateFullTypeWithLinks(mdType, lookUpType, false, false);
-
+                    }
 
                     string name = item.FullName;
+                    string summary = item.Summary;
+
+                   
+
                     if (item.ItemType == MarkdownItemTypes.Method)
                     {
-                        name = Cleaner.CreateFullMethodWithLinks(mdType, item.As<MarkdownMethod>(), false, _options.ShowParameterNames);
+                        name = Cleaner.CreateFullMethodWithLinks(mdType, item.As<MarkdownMethod>(), false, _options.ShowParameterNames, false);
                     }
                     else if(item.ItemType == MarkdownItemTypes.Property)
                     {
@@ -146,19 +150,18 @@ namespace igloo15.MarkdownApi.Core.Themes.Default
                     }
                     else if(item.ItemType == MarkdownItemTypes.Constructor)
                     {
-                        name = item.Summary;
+                        name = Cleaner.CreateFullConstructorsWithLinks(mdType, item.As<MarkdownConstructor>(), false, _options.BuildConstructorPages);
                     }
 
+                    dataValues[0] = name;
 
-                    dataValues[1] = name;
-
-                    if(headers.Length > 2)
-                        dataValues[2] = item.Summary;
+                    if(headers.Length > 1)
+                        dataValues[1] = item.Summary;
 
                     data.Add(dataValues);
                 }
 
-                mb.Table(headers, data);
+                mb.Table(headers, data, true);
                 mb.AppendLine();
             }
         }

--- a/src/MarkdownApi.Core/Themes/DefaultTheme.cs
+++ b/src/MarkdownApi.Core/Themes/DefaultTheme.cs
@@ -1,4 +1,4 @@
-﻿using igloo15.MarkdownApi.Core.Interfaces;
+using igloo15.MarkdownApi.Core.Interfaces;
 using igloo15.MarkdownApi.Core.MarkdownItems;
 using igloo15.MarkdownApi.Core.MarkdownItems.TypeParts;
 using igloo15.MarkdownApi.Core.Themes.Default;
@@ -10,142 +10,150 @@ namespace igloo15.MarkdownApi.Core.Themes
     /// This default theme is bundled with the core to provide an example and base theming for documentation generated
     /// </summary>
     public class DefaultTheme : ITheme
+  {
+    private DefaultOptions _options;
+
+    private DefaultEnumBuilder _enumBuilder;
+    private DefaultNamespaceBuilder _namespaceBuilder;
+    private DefaultProjectBuilder _projectBuilder;
+    private DefaultTypeBuilder _typeBuilder;
+    private DefaultMethodBuilder _methodBuilder;
+    internal static ILogger ThemeLogger;
+
+    /// <summary>
+    /// Constructs a default theme with the given options
+    /// </summary>
+    /// <param name="options">The options to configure the default theme</param>
+    public DefaultTheme(DefaultOptions options)
     {
-        private DefaultOptions _options;
-
-        private DefaultEnumBuilder _enumBuilder;
-        private DefaultNamespaceBuilder _namespaceBuilder;
-        private DefaultProjectBuilder _projectBuilder;
-        private DefaultTypeBuilder _typeBuilder;
-        internal static ILogger ThemeLogger;
-
-        /// <summary>
-        /// Constructs a default theme with the given options
-        /// </summary>
-        /// <param name="options">The options to configure the default theme</param>
-        public DefaultTheme(DefaultOptions options)
-        {
-            _options = options.LoadFile();
-            _enumBuilder = new DefaultEnumBuilder(_options);
-            _namespaceBuilder = new DefaultNamespaceBuilder(_options);
-            _projectBuilder = new DefaultProjectBuilder(_options);
-            _typeBuilder = new DefaultTypeBuilder(_options);
-        }
-
-        /// <summary>
-        /// The name of this theme "Default"
-        /// </summary>
-        public string Name => "Default";
-
-        /// <summary>
-        /// The Default Resolver for this theme
-        /// </summary>
-        public IResolver Resolver => new DefaultResolver(_options);
-
-        /// <summary>
-        /// Set the default logger to be used during Theme Construction
-        /// </summary>
-        /// <param name="logger">The Logger</param>
-        public void SetLogger(ILogger logger)
-        {
-            ThemeLogger = logger;
-        }
-        
-        /// <summary>
-        /// Builds Namespace Pages with the given MarkdownNamespace Item
-        /// </summary>
-        /// <param name="item">The MarkdownNamespace item to build the page with</param>
-        /// <returns>A string of the markdown content or "" if no page created</returns>
-        public string BuildPage(MarkdownNamespace item)
-        {
-            if (!_options.BuildNamespacePages)
-                return "";
-
-            return _namespaceBuilder.BuildPage(item);
-        }
-
-        /// <summary>
-        /// Builds Project Pages with the given MarkdownProject Item
-        /// </summary>
-        /// <param name="item">The MarkdownProject item to build the page with</param>
-        /// <returns>A string of the markdown content or "" if no page created</returns>
-        public string BuildPage(MarkdownProject item)
-        {
-            return _projectBuilder.BuildPage(item);
-        }
-
-        /// <summary>
-        /// Builds Type Pages with the given MarkdownType Item
-        /// </summary>
-        /// <param name="item">The item to build the page with</param>
-        /// <returns>A string of the markdown content or "" if no page created</returns>
-        public string BuildPage(MarkdownType item)
-        {
-            if (!_options.BuildTypePages)
-                return "";
-            return _typeBuilder.BuildPage(item);
-        }
-
-        /// <summary>
-        /// Builds Enum Pages with the given MarkdownEnum Item
-        /// </summary>
-        /// <param name="item">The item to build the page with</param>
-        /// <returns>A string of the markdown content or "" if no page created</returns>
-        public string BuildPage(MarkdownEnum item)
-        {
-            if (!_options.BuildTypePages)
-                return "";
-            return _enumBuilder.BuildPage(item);
-        }
-        
-        /// <summary>
-        /// In default theme this returns only ""
-        /// </summary>
-        /// <param name="item">The item to build a page with</param>
-        /// <returns>An empty string</returns>
-        public string BuildPage(MarkdownField item)
-        {
-            return "";
-        }
-
-        /// <summary>
-        /// In default theme this returns only ""
-        /// </summary>
-        /// <param name="item">The item to build a page with</param>
-        /// <returns>An empty string</returns>
-        public string BuildPage(MarkdownProperty item)
-        {
-            return "";
-        }
-
-        /// <summary>
-        /// In default theme this returns only ""
-        /// </summary>
-        /// <param name="item">The item to build a page with</param>
-        /// <returns>An empty string</returns>
-        public string BuildPage(MarkdownMethod item)
-        {
-            return "";
-        }
-
-        /// <summary>
-        /// In default theme this returns only ""
-        /// </summary>
-        /// <param name="item">The item to build a page with</param>
-        /// <returns>An empty string</returns>
-        public string BuildPage(MarkdownEvent item)
-        {
-            return "";
-        }
-
-        /// <summary>
-        /// In default theme this returns only ""
-        /// </summary>
-        /// <param name="item">The item to build a page with</param>
-        /// <returns>An empty string</returns>
-        public string BuildPage(MarkdownConstructor item)
-        {
-            return "";
-        }
+      _options = options.LoadFile();
+      _enumBuilder = new DefaultEnumBuilder(_options);
+      _namespaceBuilder = new DefaultNamespaceBuilder(_options);
+      _projectBuilder = new DefaultProjectBuilder(_options);
+      _typeBuilder = new DefaultTypeBuilder(_options);
+      _methodBuilder = new DefaultMethodBuilder(_options);
     }
+
+    /// <summary>
+    /// The name of this theme "Default"
+    /// </summary>
+    public string Name => "Default";
+
+    /// <summary>
+    /// The Default Resolver for this theme
+    /// </summary>
+    public IResolver Resolver => new DefaultResolver(_options);
+
+    /// <summary>
+    /// Set the default logger to be used during Theme Construction
+    /// </summary>
+    /// <param name="logger">The Logger</param>
+    public void SetLogger(ILogger logger)
+    {
+      ThemeLogger = logger;
+    }
+
+    /// <summary>
+    /// Builds Namespace Pages with the given MarkdownNamespace Item
+    /// </summary>
+    /// <param name="item">The MarkdownNamespace item to build the page with</param>
+    /// <returns>A string of the markdown content or "" if no page created</returns>
+    public string BuildPage(MarkdownNamespace item)
+    {
+      if (!_options.BuildNamespacePages)
+        return "";
+
+      return _namespaceBuilder.BuildPage(item);
+    }
+
+    /// <summary>
+    /// Builds Project Pages with the given MarkdownProject Item
+    /// </summary>
+    /// <param name="item">The MarkdownProject item to build the page with</param>
+    /// <returns>A string of the markdown content or "" if no page created</returns>
+    public string BuildPage(MarkdownProject item)
+    {
+      return _projectBuilder.BuildPage(item);
+    }
+
+    /// <summary>
+    /// Builds Type Pages with the given MarkdownType Item
+    /// </summary>
+    /// <param name="item">The item to build the page with</param>
+    /// <returns>A string of the markdown content or "" if no page created</returns>
+    public string BuildPage(MarkdownType item)
+    {
+      if (!_options.BuildTypePages)
+        return "";
+      return _typeBuilder.BuildPage(item);
+    }
+
+    /// <summary>
+    /// Builds Enum Pages with the given MarkdownEnum Item
+    /// </summary>
+    /// <param name="item">The item to build the page with</param>
+    /// <returns>A string of the markdown content or "" if no page created</returns>
+    public string BuildPage(MarkdownEnum item)
+    {
+      if (!_options.BuildTypePages)
+        return "";
+      return _enumBuilder.BuildPage(item);
+    }
+
+    /// <summary>
+    /// In default theme this returns only ""
+    /// </summary>
+    /// <param name="item">The item to build a page with</param>
+    /// <returns>An empty string</returns>
+    public string BuildPage(MarkdownField item)
+    {
+      return "";
+    }
+
+    /// <summary>
+    /// In default theme this returns only ""
+    /// </summary>
+    /// <param name="item">The item to build a page with</param>
+    /// <returns>An empty string</returns>
+    public string BuildPage(MarkdownProperty item)
+    {
+      return "";
+    }
+
+    /// <summary>
+    /// In default theme this returns only ""
+    /// </summary>
+    /// <param name="item">The item to build a page with</param>
+    /// <returns>An empty string</returns>
+    public string BuildPage(MarkdownMethod item)
+    {
+      if (!_options.BuildMethodPages)
+        return "";
+
+      return _methodBuilder.BuildPage(item);
+    }
+
+    /// <summary>
+    /// In default theme this returns only ""
+    /// </summary>
+    /// <param name="item">The item to build a page with</param>
+    /// <returns>An empty string</returns>
+    public string BuildPage(MarkdownEvent item)
+    {
+      return "";
+    }
+
+    /// <summary>
+    /// In default theme this returns only ""
+    /// </summary>
+    /// <param name="item">The item to build a page with</param>
+    /// <returns>An empty string</returns>
+    public string BuildPage(MarkdownConstructor item)
+    {
+      return "";
+    }
+
+
+
+  }
 }


### PR DESCRIPTION
# Added features:
Added img tag in MarkdownBuilder.cs to have a fix width table.
Added global xmlPath variable in MarkdownItemBuilder.cs to get the path in DefaultMethodBuilder.cs.
Rewritten VSDocParser.cs: para tags creates a new line, added ParseXmlParameterComment.
MarkdownMethod.cs: added Parameters property to store the Parameters.
Cleaner.cs: Changed CreateFullMethodWithLinks, added BoldName method.
DefaultMethodBuilder.cs: Now every method has its own page, with MSDN style documentation.
DefaultThemeExtension.cs: Added void, microsoft and exceptions support.
DefaultTypeBuilder.cs: Using only zeroTypeHeaders.
Extensions: Added IndexOfNth method to find line breakings.

# Known issue:
Could not figure out the usage of relative path, VSDocParser only includes absolute links. 